### PR TITLE
Fix robot inertias

### DIFF
--- a/ar4_description/config/link_properties.yaml
+++ b/ar4_description/config/link_properties.yaml
@@ -32,21 +32,18 @@
 #
 base_link:
   inertial:
+    size:
+      dx: 0.24
+      dy: 0.1
+      dz: 0.05
     origin:
-      dx: -4.6941E-06
-      dy: 0.054174
-      dz: 0.038824
+      dx: -0.05
+      dy: 0.0
+      dz: 0.02
       dr: 0.0
       dp: 0.0
       dY: 0.0
     mass: 0.7102
-    inertia:
-      ixx: 0.0039943
-      ixy: 3.697E-07
-      ixz: -5.7364E-08
-      iyy: 0.0014946
-      iyz: -0.00036051
-      izz: 0.0042554
   visual:
     origin:
       dx: 0.0
@@ -66,21 +63,18 @@ base_link:
 
 link_1:
   inertial:
-    origin:
-      dx: -0.022706
-      dy: 0.04294
-      dz: -0.12205
-      dr: 0.0
-      dp: 0.0
-      dY: 0.0
+    size:
+      dx: 0.1
+      dy: 0.1
+      dz: 0.2
     mass: 0.88065
-    inertia:
-      ixx: 0.0034
-      ixy: 0.00042296
-      ixz: -0.00089231
-      iyy: 0.0041778
-      iyz: 0.0010848
-      izz: 0.0027077
+    origin:
+      dx: 0.04
+      dy: -0.01
+      dz: 0.1
+      dr: 0.610865
+      dp: 0.418879
+      dY: 0.0
   visual:
     origin:
       dx: 0.0
@@ -100,21 +94,18 @@ link_1:
 
 link_2:
   inertial:
+    size:
+      dx: 0.1
+      dy: 0.36
+      dz: 0.1
+    mass: 0.57738
     origin:
-      dx: 0.064818
-      dy: -0.11189
-      dz: -0.038671
+      dx: 0.0
+      dy: -0.15
+      dz: 0.03
       dr: 0.0
       dp: 0.0
       dY: 0.0
-    mass: 0.57738
-    inertia:
-      ixx: 0.0047312
-      ixy: 0.0022624
-      ixz: 0.00032144
-      iyy: 0.0020836
-      iyz: -0.00056569
-      izz: 0.0056129
   visual:
     origin:
       dx: 0.0
@@ -134,21 +125,18 @@ link_2:
 
 link_3:
   inertial:
+    size:
+      dx: 0.1
+      dy: 0.12
+      dz: 0.05
+    mass: 0.1787
     origin:
-      dx: -0.00029765
-      dy: -0.023661
-      dz: -0.0019125
+      dx: -0.01
+      dy: 0.0
+      dz: 0.0
       dr: 0.0
       dp: 0.0
       dY: 0.0
-    mass: 0.1787
-    inertia:
-      ixx: 0.0001685
-      ixy: -2.7713E-05
-      ixz: 5.6885E-06
-      iyy: 0.00012865
-      iyz: 2.9256E-05
-      izz: 0.00020744
   visual:
     origin:
       dx: 0.0
@@ -168,21 +156,18 @@ link_3:
 
 link_4:
   inertial:
+    size:
+      dx: 0.06
+      dy: 0.06
+      dz: 0.32
+    mass: 0.34936
     origin:
-      dx: -0.0016798
-      dy: 0.00057319
-      dz: -0.074404
+      dx: 0.0
+      dy: 0.0
+      dz: 0.08
       dr: 0.0
       dp: 0.0
       dY: 0.0
-    mass: 0.34936
-    inertia:
-      ixx: 0.0030532
-      ixy: -1.8615E-05
-      ixz: -7.0047E-05
-      iyy: 0.0031033
-      iyz: 2.3301E-05
-      izz: 0.00022264
   visual:
     origin:
       dx: 0.0
@@ -202,21 +187,18 @@ link_4:
 
 link_5:
   inertial:
+    size:
+      dx: 0.1
+      dy: 0.04
+      dz: 0.08
+    mass: 0.11562
     origin:
-      dx: 0.0015066
-      dy: -1.3102E-05
-      dz: -0.012585
+      dx: 0.0
+      dy: 0.0
+      dz: 0.0
       dr: 0.0
       dp: 0.0
       dY: 0.0
-    mass: 0.11562
-    inertia:
-      ixx: 5.5035E-05
-      ixy: -1.019E-08
-      ixz: -2.6243E-06
-      iyy: 8.2921E-05
-      iyz: 1.4437E-08
-      izz: 5.2518E-05
   visual:
     origin:
       dx: 0.0
@@ -236,21 +218,18 @@ link_5:
 
 link_6:
   inertial:
+    size:
+      dx: 0.04
+      dy: 0.02
+      dz: 0.02
+    mass: 0.013863
     origin:
-      dx: 2.9287E-10
-      dy: -1.6472E-09
-      dz: 0.0091432
+      dx: 0.0
+      dy: 0.0
+      dz: -0.01
       dr: 0.0
       dp: 0.0
       dY: 0.0
-    mass: 0.013863
-    inertia:
-      ixx: 1.3596E-06
-      ixy: 3.0585E-13
-      ixz: 5.7102E-14
-      iyy: 1.7157E-06
-      iyz: 6.3369E-09
-      izz: 2.4332E-06
   visual:
     origin:
       dx: 0.0

--- a/ar4_description/urdf/ar4.urdf.xacro
+++ b/ar4_description/urdf/ar4.urdf.xacro
@@ -25,7 +25,7 @@
     <parent link="base_link"/>
     <child link="link_1"/>
     <axis xyz="0 0 1"/>
-    <limit lower="${-170.0 / 180.0 * pi}" upper="${170.0 / 180.0 * pi}" effort="0" velocity="0.5"/>
+    <limit lower="${-170.0 / 180.0 * pi}" upper="${170.0 / 180.0 * pi}" effort="100" velocity="0.5"/>
   </joint>
 
   <xacro:link link_name="link_2"
@@ -39,7 +39,7 @@
     <parent link="link_1"/>
     <child link="link_2"/>
     <axis xyz="0 0 1"/>
-    <limit lower="${-42.0 / 180.0 * pi}" upper="${90.0 / 180.0 * pi}" effort="0.5" velocity="0.5"/>
+    <limit lower="${-42.0 / 180.0 * pi}" upper="${90.0 / 180.0 * pi}" effort="100" velocity="0.5"/>
   </joint>
 
   <xacro:link link_name="link_3"
@@ -53,7 +53,7 @@
     <parent link="link_2"/>
     <child link="link_3"/>
     <axis xyz="0 0 1"/>
-    <limit lower="${-89.0 / 180.0 * pi}" upper="${52.0 / 180.0 * pi}" effort="0" velocity="0.5"/>
+    <limit lower="${-89.0 / 180.0 * pi}" upper="${52.0 / 180.0 * pi}" effort="100" velocity="0.5"/>
   </joint>
 
   <xacro:link link_name="link_4"
@@ -67,7 +67,7 @@
     <parent link="link_3"/>
     <child link="link_4"/>
     <axis xyz="0 0 1"/>
-    <limit lower="${-1 * robot_parameters['j4_limit']}" upper="${robot_parameters['j4_limit']}" effort="0" velocity="0.5"/>
+    <limit lower="${-1 * robot_parameters['j4_limit']}" upper="${robot_parameters['j4_limit']}" effort="100" velocity="0.5"/>
   </joint>
 
   <xacro:link link_name="link_5"
@@ -81,7 +81,7 @@
     <parent link="link_4"/>
     <child link="link_5"/>
     <axis xyz="0 0 1"/>
-    <limit lower="${-105.0 / 180.0 * pi}" upper="${105.0 / 180.0 * pi}" effort="0" velocity="1.0"/>
+    <limit lower="${-105.0 / 180.0 * pi}" upper="${105.0 / 180.0 * pi}" effort="100" velocity="1.0"/>
   </joint>
 
   <xacro:link link_name="link_6"
@@ -95,6 +95,6 @@
     <parent link="link_5"/>
     <child link="link_6"/>
     <axis xyz="0 0 1"/>
-    <limit lower="${-1.0 * robot_parameters['j6_limit']}" upper="${robot_parameters['j6_limit']}" effort="0" velocity="1.0"/>
+    <limit lower="${-1.0 * robot_parameters['j6_limit']}" upper="${robot_parameters['j6_limit']}" effort="100" velocity="1.0"/>
   </joint>
 </robot>

--- a/ar4_description/urdf/include/common_macros.urdf.xacro
+++ b/ar4_description/urdf/include/common_macros.urdf.xacro
@@ -1,23 +1,17 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+<!-- ===================== Arm link xacro ================================== -->
+
   <xacro:macro name="link" params="link_name *origin inertial visual collision">
     <link name="${link_name}">
       <xacro:insert_block name="origin"/>
-      <inertial>
-        <origin rpy="${inertial['origin']['dr']}
-                     ${inertial['origin']['dp']}
-                     ${inertial['origin']['dY']}"
-                xyz="${inertial['origin']['dx']}
-                     ${inertial['origin']['dy']}
-                     ${inertial['origin']['dz']}"/>
-        <mass value="${inertial['mass']}"/>
-        <inertia ixx="${inertial['inertia']['ixx']}"
-                 ixy="${inertial['inertia']['ixy']}"
-                 ixz="${inertial['inertia']['ixz']}"
-                 iyy="${inertial['inertia']['iyy']}"
-                 iyz="${inertial['inertia']['iyz']}"
-                 izz="${inertial['inertia']['izz']}"/>
-      </inertial>
+      <xacro:box_inertia m="${inertial['mass']}"
+                         x="${inertial['size']['dx']}"
+                         y="${inertial['size']['dy']}"
+                         z="${inertial['size']['dz']}"
+                         o_xyz="${inertial['origin']['dx']} ${inertial['origin']['dy']} ${inertial['origin']['dz']}"
+                         o_rpy="${inertial['origin']['dr']} ${inertial['origin']['dp']} ${inertial['origin']['dY']}">
+      </xacro:box_inertia>
       <visual>
         <origin rpy="${visual['origin']['dr']}
                      ${visual['origin']['dp']}
@@ -45,4 +39,26 @@
       </collision>
     </link>
   </xacro:macro>
+
+<!-- ===================== Box inertia xacro ==================================
+
+  params:
+  - m [float]: link mass;
+  - x [float]: link dimension on the X-axis;
+  - y [float]: link dimension on the Y-axis;
+  - z [float]: link dimension on the Z-axis;
+  - o_xyz [string]: position offset
+  - o_rpy [string]: rotation offset
+-->
+
+ <xacro:macro name="box_inertia" params="m x y z o_xyz:='0.0 0.0 0.0' o_rpy:='0.0 0.0 0.0'">
+    <inertial>
+      <mass value="${m}"/>
+      <inertia ixx="${m / 12.0 * (y*y + z*z)}" ixy="0.0" ixz="0.0"
+               iyy="${m / 12.0 * (x*x + z*z)}" iyz="0.0"
+               izz="${m / 12.0 * (x*x + y*y)}"/>
+      <origin xyz="${o_xyz}" rpy="${o_rpy}" />
+    </inertial>
+  </xacro:macro>
+
 </robot>


### PR DESCRIPTION
## Summary

This patch fixes the inertia issues present in this branch by using a macro to calculate the box inertia taking into account and estimate of each individual part of the robot.

Issue [#36](https://github.com/ekumenlabs/ar4/issues/36)

## Testing

Launch Gazebo
```
source install/setup.bash
ros2 launch ar4_gazebo ar4_in_empty_world.launch.py
```

With the changes in `effort` the arm should be stable, select `View -> Inertia` and see:
![Screenshot from 2025-01-28 15-05-01](https://github.com/user-attachments/assets/15bdb8c2-7d9e-4d0c-bbb3-58303866c4e4)



