### PR TITLE
Use host user ID for the docker user

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,11 +17,11 @@ RUN --mount=type=cache,target=/var/cache/apt \
 # Set user and fixuid configuration
 ARG USER=developer
 ARG GROUP=ekumen
-ARG UID=1000
-ARG GID=1000
+ARG USERID=1000
+ARG GROUPID=1000
 
-RUN addgroup --gid $GID $GROUP \
-    && adduser --uid $UID --ingroup $GROUP --home /home/$USER --shell /bin/sh --disabled-password --gecos "" $USER \
+RUN addgroup --gid $GROUPID $GROUP \
+    && adduser --uid $USERID --ingroup $GROUP --home /home/$USER --shell /bin/sh --disabled-password --gecos "" $USER \
     && adduser $USER sudo \
     && echo "$USER ALL=NOPASSWD: ALL" >> /etc/sudoers.d/$USER
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,6 +3,9 @@ services:
     build:
       dockerfile: docker/Dockerfile
       context: ../
+      args:
+        USERID: ${USERID}
+        GROUPID: ${GROUPID}
     image: ar4_gazebo
     container_name: ar4_gazebo
     hostname: ar4_gazebo

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -33,4 +33,7 @@ done
 
 cd $(dirname $0)
 
+export USERID=$(id -u)
+export GROUPID=$(id -g)
+
 docker compose run --rm ${BUILD:+--build} $SERVICE


### PR DESCRIPTION
This patch fixes a permission issue where `colcon build` failed if the
host and Docker user IDs didn’t match. This ensures the Docker user
matches the host user, preventing build file creation errors.