### PR TITLE
added wrapped launch file

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,36 +50,37 @@ Source the built packages
 source install/setup.bash
 ```
 
+---
+
 ### Launch the simulation
 
-After building and sourcing the packages, run the Gazebo simulation
+After building and sourcing the packages, run the Gazebo simulation:
 
 ```
-ros2 launch ar4_gazebo ar4_in_empty_world.launch.py
+ros2 launch ar4_gazebo gazebo_moveit.launch.py
 ```
 
 ![Ar4 Gazebo](docs/ar4.png)
 
+By default, this will launch the simulation with the ROS bridge enabled.
 
-To use Gazebo with ROS running the bridge:
 
-```
-ros2 launch ar4_gazebo gz_ros_bridge.launch.py
-```
 
-### Controlling the arm with Moveit
-
-To plan and command the arm to execute a motion launch the `demo.launch.py`:
+If you want to disable the ROS bridge, use:
 
 ```
-ros2 launch ar4_moveit_config demo.launch.py
+ros2 launch ar4_gazebo gazebo_moveit.launch.py use_ros_bridge:=false
 ```
 
-You should see RViz showing the robot visualization and the MotionPlanning panel at the left.
+### Controlling the arm with MoveIt
+
+To plan and command the arm to execute a motion, this launch file will also start MoveIt automatically. Once launched, you should see RViz showing the robot visualization and the MotionPlanning panel on the left.
 
 There are two ways of selecting a target position for the arm, both through RViz:
+- Selecting a random valid position.
+- Moving the end effector to a desired position.
 
-Selecting a random valid position or moving the end effector to a desired position.
+---
 
 ### Selecting random valid position
 This will select a random position for the arm that would not cause a collision with itself or objects around it, calculated from the semantic information of the robot.

--- a/ar4_gazebo/launch/gazebo_moveit.launch.py
+++ b/ar4_gazebo/launch/gazebo_moveit.launch.py
@@ -1,0 +1,58 @@
+import launch
+import launch_ros.actions
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription, TimerAction, DeclareLaunchArgument
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch_ros.substitutions import FindPackageShare
+from launch.substitutions import LaunchConfiguration
+import os
+
+
+def generate_launch_description():
+    ar4_gazebo_pkg = 'ar4_gazebo'
+    ar4_moveit_config_pkg = 'ar4_moveit_config'
+
+    # Declare launch argument for enabling/disabling the ros bridge
+    use_ros_bridge = LaunchConfiguration('use_ros_bridge')
+    
+    declare_use_ros_bridge = DeclareLaunchArgument(
+        'use_ros_bridge', default_value='true', description='Enable ROS bridge')
+
+    # Launch ar4_in_empty_world.launch.py
+    gazebo_launch = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([
+            os.path.join(FindPackageShare(ar4_gazebo_pkg).find(ar4_gazebo_pkg), 'launch', 'ar4_in_empty_world.launch.py')
+        ])
+    )
+
+    # Launch gz_ros_bridge.launch.py after Gazebo if enabled
+    gz_ros_bridge_launch = TimerAction(
+        period=5.0,  # Adjust delay as needed
+        actions=[
+            IncludeLaunchDescription(
+                PythonLaunchDescriptionSource([
+                    os.path.join(FindPackageShare(ar4_gazebo_pkg).find(ar4_gazebo_pkg), 'launch', 'gz_ros_bridge.launch.py')
+                ])
+            )
+        ],
+        condition=launch.conditions.IfCondition(use_ros_bridge)
+    )
+
+    # Launch demo.launch.py after gz_ros_bridge
+    moveit_launch = TimerAction(
+        period=10.0,  # Adjust delay as needed
+        actions=[
+            IncludeLaunchDescription(
+                PythonLaunchDescriptionSource([
+                    os.path.join(FindPackageShare(ar4_moveit_config_pkg).find(ar4_moveit_config_pkg), 'launch', 'demo.launch.py')
+                ])
+            )
+        ]
+    )
+
+    return LaunchDescription([
+        declare_use_ros_bridge,
+        gazebo_launch,
+        gz_ros_bridge_launch,
+        moveit_launch
+    ])

--- a/ar4_gazebo/launch/gazebo_moveit.launch.py
+++ b/ar4_gazebo/launch/gazebo_moveit.launch.py
@@ -1,7 +1,39 @@
+# BSD 3-Clause License
+#
+# Copyright 2025 Ekumen, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""launch file for integrating Gazebo with MoveIt for the AR4 robot."""
+
 import launch
-import launch_ros.actions
 from launch import LaunchDescription
-from launch.actions import IncludeLaunchDescription, TimerAction, DeclareLaunchArgument
+from launch.actions import IncludeLaunchDescription, DeclareLaunchArgument
+from launch.actions import GroupAction
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_ros.substitutions import FindPackageShare
 from launch.substitutions import LaunchConfiguration
@@ -9,50 +41,61 @@ import os
 
 
 def generate_launch_description():
+    """Launch the AR4 robot in Gazebo and MoveIt."""
     ar4_gazebo_pkg = 'ar4_gazebo'
     ar4_moveit_config_pkg = 'ar4_moveit_config'
 
     # Declare launch argument for enabling/disabling the ros bridge
     use_ros_bridge = LaunchConfiguration('use_ros_bridge')
-    
+
     declare_use_ros_bridge = DeclareLaunchArgument(
-        'use_ros_bridge', default_value='true', description='Enable ROS bridge')
+        'use_ros_bridge', default_value='true', description='Enable ROS bridge'
+    )
 
     # Launch ar4_in_empty_world.launch.py
     gazebo_launch = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([
-            os.path.join(FindPackageShare(ar4_gazebo_pkg).find(ar4_gazebo_pkg), 'launch', 'ar4_in_empty_world.launch.py')
-        ])
+        PythonLaunchDescriptionSource(
+            [
+                os.path.join(
+                    FindPackageShare(ar4_gazebo_pkg).find(ar4_gazebo_pkg),
+                    'launch',
+                    'ar4_in_empty_world.launch.py',
+                )
+            ]
+        )
     )
 
-    # Launch gz_ros_bridge.launch.py after Gazebo if enabled
-    gz_ros_bridge_launch = TimerAction(
-        period=5.0,  # Adjust delay as needed
-        actions=[
+    # Launch gz_ros_bridge.launch.py only if use_ros_bridge is true
+    gz_ros_bridge_launch = GroupAction(
+        [
             IncludeLaunchDescription(
-                PythonLaunchDescriptionSource([
-                    os.path.join(FindPackageShare(ar4_gazebo_pkg).find(ar4_gazebo_pkg), 'launch', 'gz_ros_bridge.launch.py')
-                ])
+                PythonLaunchDescriptionSource(
+                    [
+                        os.path.join(
+                            FindPackageShare(ar4_gazebo_pkg).find(ar4_gazebo_pkg),
+                            'launch',
+                            'gz_ros_bridge.launch.py',
+                        )
+                    ]
+                )
             )
         ],
-        condition=launch.conditions.IfCondition(use_ros_bridge)
+        condition=launch.conditions.IfCondition(use_ros_bridge),
     )
 
-    # Launch demo.launch.py after gz_ros_bridge
-    moveit_launch = TimerAction(
-        period=10.0,  # Adjust delay as needed
-        actions=[
-            IncludeLaunchDescription(
-                PythonLaunchDescriptionSource([
-                    os.path.join(FindPackageShare(ar4_moveit_config_pkg).find(ar4_moveit_config_pkg), 'launch', 'demo.launch.py')
-                ])
-            )
-        ]
+    # Launch demo.launch.py
+    moveit_launch = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            [
+                os.path.join(
+                    FindPackageShare(ar4_moveit_config_pkg).find(ar4_moveit_config_pkg),
+                    'launch',
+                    'demo.launch.py',
+                )
+            ]
+        )
     )
 
-    return LaunchDescription([
-        declare_use_ros_bridge,
-        gazebo_launch,
-        gz_ros_bridge_launch,
-        moveit_launch
-    ])
+    return LaunchDescription(
+        [declare_use_ros_bridge, gazebo_launch, gz_ros_bridge_launch, moveit_launch]
+    )

--- a/ar4_gazebo/launch/gazebo_moveit.launch.py
+++ b/ar4_gazebo/launch/gazebo_moveit.launch.py
@@ -30,14 +30,13 @@
 
 """launch file for integrating Gazebo with MoveIt for the AR4 robot."""
 
-import launch
 from launch import LaunchDescription
 from launch.actions import IncludeLaunchDescription, DeclareLaunchArgument
 from launch.actions import GroupAction
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_ros.substitutions import FindPackageShare
-from launch.substitutions import LaunchConfiguration
-import os
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch.conditions import IfCondition
 
 
 def generate_launch_description():
@@ -55,13 +54,13 @@ def generate_launch_description():
     # Launch ar4_in_empty_world.launch.py
     gazebo_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
-            [
-                os.path.join(
-                    FindPackageShare(ar4_gazebo_pkg).find(ar4_gazebo_pkg),
+            PathJoinSubstitution(
+                [
+                    FindPackageShare(ar4_gazebo_pkg),
                     'launch',
                     'ar4_in_empty_world.launch.py',
-                )
-            ]
+                ]
+            )
         )
     )
 
@@ -70,32 +69,37 @@ def generate_launch_description():
         [
             IncludeLaunchDescription(
                 PythonLaunchDescriptionSource(
-                    [
-                        os.path.join(
-                            FindPackageShare(ar4_gazebo_pkg).find(ar4_gazebo_pkg),
+                    PathJoinSubstitution(
+                        [
+                            FindPackageShare(ar4_gazebo_pkg),
                             'launch',
                             'gz_ros_bridge.launch.py',
-                        )
-                    ]
+                        ]
+                    )
                 )
             )
         ],
-        condition=launch.conditions.IfCondition(use_ros_bridge),
+        condition=IfCondition(use_ros_bridge),
     )
 
     # Launch demo.launch.py
     moveit_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
-            [
-                os.path.join(
-                    FindPackageShare(ar4_moveit_config_pkg).find(ar4_moveit_config_pkg),
+            PathJoinSubstitution(
+                [
+                    FindPackageShare(ar4_moveit_config_pkg),
                     'launch',
                     'demo.launch.py',
-                )
-            ]
+                ]
+            )
         )
     )
 
     return LaunchDescription(
-        [declare_use_ros_bridge, gazebo_launch, gz_ros_bridge_launch, moveit_launch]
+        [
+            declare_use_ros_bridge,
+            gazebo_launch,
+            gz_ros_bridge_launch,
+            moveit_launch,
+        ]
     )


### PR DESCRIPTION
This patch adds the `gazebo_moveit.launch.py` file to the `ar4_gazebo` package, providing a unified way to launch the Gazebo simulation, ROS bridge, and MoveIt in sequence. 

Issue [#39](https://github.com/ekumenlabs/ar4/issues/39)

### Key changes:
- Introduces a launch argument `use_ros_bridge` to allow enabling or disabling the ROS-Gazebo bridge dynamically.
- Ensures `ar4_in_empty_world.launch.py` starts first, followed by `gz_ros_bridge.launch.py` (if enabled), and finally `demo.launch.py` from `ar4_moveit_config`.
- Improves usability by consolidating multiple launch steps into a single command.

With this update, users can start the full simulation with:
```
ros2 launch ar4_gazebo gazebo_moveit.launch.py
```
or disable the ROS bridge if needed:
```
ros2 launch ar4_gazebo gazebo_moveit.launch.py use_ros_bridge:=false
```