### PR TITLE
Add docker configuration for accesing the real robot

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,18 @@ It is a requirement to have `docker engine` with the `docker compose plugin` alr
 
 #### Building and running the ar4 dev container
 
-**Important note:** If real robot is going to be used, it is required to:
-- Connect the device to the computer before running the container.
-- Uncoment the comented lines in [docker-compose.yml](./docker/docker-compose.yml) to give the container access to the teensy.
 
-Build and/or run the container
+Build and/or run the container for Gazebo simulation
 ```bash
 ./docker/run.sh
+```
+
+Build and/or run the container for the real robot:
+
+1. Connect the teensy usb to the computer
+2. Run: 
+```bash
+./docker/run.sh -s ar4_hardware
 ```
 
 Force rebuilding the image

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Build and/or run the container for Gazebo simulation
 Build and/or run the container for the real robot:
 
 1. Connect the teensy usb to the computer
-2. Run: 
+2. Run:
 ```bash
 ./docker/run.sh -s ar4_hardware
 ```

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ It is a requirement to have `docker engine` with the `docker compose plugin` alr
 
 #### Building and running the ar4 dev container
 
+**Important note:** If real robot is going to be used, it is required to:
+- Connect the device to the computer before running the container.
+- Uncoment the comented lines in [docker-compose.yml](./docker/docker-compose.yml) to give the container access to the teensy.
+
+
 Build and/or run the container
 ```bash
 ./docker/run.sh

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ It is a requirement to have `docker engine` with the `docker compose plugin` alr
 - Connect the device to the computer before running the container.
 - Uncoment the comented lines in [docker-compose.yml](./docker/docker-compose.yml) to give the container access to the teensy.
 
-
 Build and/or run the container
 ```bash
 ./docker/run.sh

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -19,3 +19,8 @@ services:
     volumes:
       - ../:/workspace/src/ar4
       - /tmp/.X11-unix/:/tmp/.X11-unix/
+    # Uncomment the lines below if you want to connect the real robot.
+    # devices:
+    #   - "/dev/ttyACM0:/dev/ttyACM0:rwm" # Serial port for the teensy
+    # group_add:
+    #   - "dialout" # Group required for accesing /dev/ttyACM0

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -19,8 +19,9 @@ services:
     volumes:
       - ../:/workspace/src/ar4
       - /tmp/.X11-unix/:/tmp/.X11-unix/
-    # Uncomment the lines below if you want to connect the real robot.
-    # devices:
-    #   - "/dev/ttyACM0:/dev/ttyACM0:rwm" # Serial port for the teensy
-    # group_add:
-    #   - "dialout" # Group required for accesing /dev/ttyACM0
+  ar4_hardware:
+    extends: ar4_gazebo
+    devices:
+      - "/dev/ttyACM0:/dev/ttyACM0:rwm" # Serial port for the teensy
+    group_add:
+      - "dialout" # Group required for accesing /dev/ttyACM0


### PR DESCRIPTION
This PR adds the docker-compose configuration to let the docker container access the real robot.

Rationale:
- The docker container has to work with and without the robot connected to the computer as one could just want to test the simulation.
- With the device mapping set (`"/dev/ttyACM0:/dev/ttyACM0:rwm"`), if the robot is not connected to the computer, running the compose fails as it doesn't find `/dev/ttyACM0` in the host computer.
- The other alternative is setting a volume for the whole /dev directory and run the container as privileged which is pretty invasive.

Solution: Add the configuration to access the real robot as commented lines and a note in the README letting devs know that if they want to use the real robot, they have to uncomment those lines.

CC @frneer @glpuga 